### PR TITLE
Bump dependencies and no longer depened on async-std attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,13 @@ keywords = ["tide", "static", "files"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tide = "0.4.0"
+tide = "0.5.1"
 http = "0.1.20"
-bytes = "0.5.2"
+bytes = "0.5.3"
 futures-fs = "0.0.5"
 futures-util = "0.3.1"
 http-service = "0.4.0"
 mime = "0.3.14"
 mime_guess = "2.0.1"
 percent-encoding = "2.1.0"
-
-[dependencies.async-std]
-version = "1.2.0"
-features = [ "attributes" ]
+async-std = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To use the library:
 ```rust
 use std::path::{Path, PathBuf};
 use tide_naive_static_files::{serve_static_files, StaticRootDir};
+use async_std::task;
 
 struct AppState { // 1.
     static_root_dir: PathBuf,
@@ -34,8 +35,7 @@ impl StaticRootDir for AppState { // 2.
     }
 }
 
-#[async_std::main]
-async fn main() {
+fn main() {
     let state = AppState {
         static_root_dir: "./examples/".into(),
     };
@@ -43,7 +43,10 @@ async fn main() {
     let mut app = tide::with_state(state);
     app.at("/static/*path") // 3.
         .get(|req| async { serve_static_files(req).await.unwrap() });
-    app.listen("127.0.0.1:8000").await.unwrap();
+
+    task::block_on(async move {
+        app.listen("127.0.0.1:8000").await.unwrap();
+    })
 }
 ```
 

--- a/examples/static-file-server.rs
+++ b/examples/static-file-server.rs
@@ -11,8 +11,7 @@ impl StaticRootDir for AppState {
     }
 }
 
-#[async_std::main]
-async fn main() {
+fn main() {
     let state = AppState {
         static_root_dir: "./examples/".into(),
     };
@@ -20,5 +19,8 @@ async fn main() {
     let mut app = tide::with_state(state);
     app.at("static/*path")
         .get(|req| async { serve_static_files(req).await.unwrap() });
-    app.listen("127.0.0.1:8000").await.unwrap();
+
+    async_std::task::block_on(async move {
+        app.listen("127.0.0.1:8000").await
+    });
 }

--- a/examples/static-file-server.rs
+++ b/examples/static-file-server.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use tide_naive_static_files::{serve_static_files, StaticRootDir};
+use async_std::task;
 
 struct AppState {
     static_root_dir: PathBuf,
@@ -20,7 +21,7 @@ fn main() {
     app.at("static/*path")
         .get(|req| async { serve_static_files(req).await.unwrap() });
 
-    async_std::task::block_on(async move {
-        app.listen("127.0.0.1:8000").await
+    task::block_on(async move {
+        app.listen("127.0.0.1:8000").await.unwrap()
     });
 }


### PR DESCRIPTION
Bump the versions so it can be used with the latest tide release.
I also removed the dependency on the `attribtues` feature of `async-std` to make it compile faster (no need to compile `syn` :) )